### PR TITLE
Change NoCsrfSecurityConfig Order to 2

### DIFF
--- a/src/test/java/auto_ckz/config/NoCsrfSecurityConfig.java
+++ b/src/test/java/auto_ckz/config/NoCsrfSecurityConfig.java
@@ -8,7 +8,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 
 @Configuration
 @Profile("test")
-@Order(1)
+@Order(2)
 public class NoCsrfSecurityConfig extends SecurityConfig {
 
     @Override


### PR DESCRIPTION
Without this change, tests are failing due to configuration ordering conflict (due to presence of `@Order(1)` annotation in `SecurityConfig.java`).